### PR TITLE
Ermäßigter Mitgliedsbeitrag für Auszubildende

### DIFF
--- a/Beitragsordnung.tex
+++ b/Beitragsordnung.tex
@@ -15,7 +15,8 @@
 \section{Beitragssätze}
 \begin{enumerate}
   \item Der reguläre Mitgliedsbeitrag beträgt 20€ pro Monat.
-  \item Schüler, Studenten, Empfänger von Sozialgeld oder Arbeitslosengeld~II
+  \item Schüler, Studenten, Auszubildende, Empfänger von Sozialgeld oder
+    Arbeitslosengeld~II
     einschließlich Leistungen nach §~22 ohne Zuschläge oder nach §~24 des
     Zweiten Buchs des Sozialgesetzbuchs (SGB~II), sowie Empfänger von
     Ausbildungsförderung nach dem Bundesausbildungsförderungsgesetz (BAföG)


### PR DESCRIPTION
Studenten und Schüler zahlen den ermäßigten Beitrag, es gibt keinen Grund, warum Auszubildende den vollen Beitrag zahlen sollten.
