### PR TITLE
Satzung: Einladung zu Vorstandssitzungen durch beliebiges Vorstandsmitglied erlauben

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -179,8 +179,8 @@
     Tagesordnungspunkte beschließen, diese unter Ausschluss der restlichen
     Mitglieder zu behandeln. Der Grund für den Ausschluss der Mitglieder muss im
     Protokoll festgehalten werden.
-  \item Die Einladung zu Vorstandssitzungen erfolgt durch den
-    Vorstandsvorsitzenden oder den stellvertretenden Vorsitzenden in Textform
+  \item Die Einladung zu Vorstandssitzungen erfolgt durch ein Mitglied des
+    Vorstands in Textform
     unter Einhaltung einer Einladungsfrist von mindestens 7~Tagen. Die Einladung
     muss außerdem an geeigneter Stelle für alle Mitglieder des Vereins
     veröffentlicht werden.


### PR DESCRIPTION
Ist sinnvoll für Fälle, in denen der erste oder der stellvertretende
Vorstandsvorsitzende nicht verfügbar ist. Außerdem besteht kein Grund dafür,
dass diese Formalität nur von diesen beiden Entitäten ausgeführt werden sollte.
