### PR TITLE
Bestätigung des Vorstands möglich machen, Amtszeit bis zur Neuwahl beschränken

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -163,8 +163,7 @@
     Jahr gewählt. Es kann durch Beschluss der Mitgliederversammlung auf eine
     Wahl der Beisitzer verzichtet werden. Die Bestätigung des Vorstandes oder
     die Wiederwahl der Vorstandsmitglieder ist möglich. Die jeweils amtierenden
-    Vorstandsmitglieder bleiben nach Ablauf ihrer Amtszeit im Amt, bis
-    Nachfolger gewählt sind.
+    Vorstandsmitglieder bleiben im Amt, bis Nachfolger gewählt sind.
   \item Dem Vorstand obliegt die Führung der laufenden Geschäfte des Vereins. Er
     hat insbesondere folgende Rechte:
     \begin{itemize}


### PR DESCRIPTION
- Bestätigung des Vorstands gilt als Blockwahl; dies ist nicht zulässig, sofern nicht explizit in der Satzung geregelt. Siehe auch: http://www.verein-aktuell.de/vereinsrecht-organisation-fuehrung/vorstand-mitgliederversammlung-co/bei-vorstands-blockwahl-in-der-mitgliederversammlung--die-vereinssatzung-unbedingt-zuvor-beachten
- Amtszeit der Vorstandsmitglieder bis zur Neuwahl des Amts beschränken. Ansonsten problematisch, wenn der Wille besteht, gewählte Vorstandsmitglieder vor Ablauf ihrer Amtszeit abzusetzen.
