### PR TITLE
Satzung: Keine besondere Begrenzung der Amtszeit bei Nachfolgern von vakant gewordenen Vorstandsposten

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -196,11 +196,10 @@
     gesunken, ist der restliche Vorstand verpflichtet, unverzüglich, spätestens
     jedoch innerhalb von 14~Tagen, zu einer zeitnahen Mitgliederversammlung
     einzuladen.
-  \item Für vakant gewordene Vorstandsposten wird auf der nächsten
-    Mitgliederversammlung jeweils ein Nachfolger bestimmt, der für die restliche
-    Dauer der Amtszeit seines Vorgängers im Amt bleibt. Bei vakant gewordenen
-    Beisitzerposten kann ein Nachfolger nach Beschluss der Mitgliederversammlung
-    entfallen.
+  \item Für vakant gewordene Vorstandsposten muss auf der nächsten
+    Mitgliederversammlung jeweils ein Nachfolger bestimmt werden.
+    Bei vakant gewordenen Beisitzerposten kann ein Nachfolger nach Beschluss der
+    Mitgliederversammlung entfallen.
   \item Der Vorstand gibt sich eine Geschäftsordnung, worin unter anderem die
     Aufgabenteilung des Vorstandes geregelt wird.
   \item Die Amtszeit des auf der Gründungsversammlung gewählten Vorstandes endet


### PR DESCRIPTION
Sonst könnte folgendes passieren:
- Ein Vorstandsmitglied (z.B. Schatzmeister) tritt 4 Wochen vor Ende der Amtszeit zurück
- Nach Einberufung einer Mitgliederversammlung wird 2 Wochen später ein Nachfolger bestimmt => dieser Nachfolger hat dann nur eine Amtszeit von 2 Wochen, danach muss wieder
  neu gewählt werden.
