### PR TITLE
Beitragsordnung: Befreiung oder Ermäßigung des Beitrags auf 3 Monate beschränken

### DIFF
--- a/Beitragsordnung.tex
+++ b/Beitragsordnung.tex
@@ -25,7 +25,7 @@
     zugänglich gemacht werden.
   \item Sollte ein Mitglied aus finanziellen Gründen den Mitgliedsbeitrag nicht
     aufbringen können, kann dieses beim Vorstand einen Antrag auf Ermäßigung
-    oder Befreiung stellen. Diese gilt für ein Jahr und kann dann durch einen
+    oder Befreiung stellen. Diese gilt für drei Monate und kann dann durch einen
     neuen Antrag erneuert werden.
   \item Alle Mitglieder werden ermutigt, im Rahmen ihrer Möglichkeiten eine
     regelmäßige Spende an den Verein zu entrichten. Empfohlen wird eine Spende


### PR DESCRIPTION
Die Beschränkung auf 3 Monate soll verhindern, dass Mitglieder diese Regelung zum Nachteil des Vereins ausnutzen, falls aus ihrer Sicht nur weniger als ein Jahr Begünstigung benötigt wird. Insofern soll die neue Regelung mehr Flexibilität bieten und verhindern, dass die Begünstigung zu lange bewilligt wird und dem Verein Mitgliedsbeiträge entgehen.

Das Gegenargument, dass nun vier Anträge für ein volles Jahr Begünstigung nötig sind (falls überhaupt ein volles Jahr benötigt wird), wird dadurch entkräftet, dass vier fast gleiche Anträge an den Vorstand kein großer Aufwand sein sollten.
