### PR TITLE
Satzung: Beschlüsse der Mitgliederversammlung haben Vorrang

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -147,6 +147,8 @@
   \item Die Mitgliederversammlung fasst ihre Beschlüsse mit einfacher Mehrheit
     der anwesenden Mitglieder, sofern in dieser Satzung nicht anders geregelt.
     Bei Stimmengleichheit gilt ein Antrag als abgelehnt.
+    Im Fall von gegensätzlichen Beschlüssen haben die Beschlüsse der
+    Mitgliederversammlung Vorrang vor denen anderer Vereinsorgane.
   \item Die Ausübung des Stimmrechts auf der Mitgliederversammlung ist nur 
     möglich, wenn bis zum Zeitpunkt der Inanspruchnahme des e.~g. Rechts, 
     alle offenen Mitgliedsbeiträge des entsprechenden Mitglieds beglichen


### PR DESCRIPTION
um Unsicherheiten zu vermeiden, siehe z.B. Vorstandsentscheidungen zu Space 2.0
