### PR TITLE
Beitragsbefreiung für maximal ein Jahr

### DIFF
--- a/Beitragsordnung.tex
+++ b/Beitragsordnung.tex
@@ -25,7 +25,7 @@
     zugänglich gemacht werden.
   \item Sollte ein Mitglied aus finanziellen Gründen den Mitgliedsbeitrag nicht
     aufbringen können, kann dieses beim Vorstand einen Antrag auf Ermäßigung
-    oder Befreiung stellen. Diese gilt für ein Jahr und kann dann durch einen
+    oder Befreiung stellen. Diese gilt für maximal ein Jahr und kann dann durch einen
     neuen Antrag erneuert werden.
   \item Alle Mitglieder werden ermutigt, im Rahmen ihrer Möglichkeiten eine
     regelmäßige Spende an den Verein zu entrichten. Empfohlen wird eine Spende


### PR DESCRIPTION
Dies wurde auf der Vorstandssitzung 2013-05-13 für sinnvoll befunden, um einerseits den Anforderungen der antragstellenden Entitäten gerecht zu werden, andererseits aber auch nicht unnötig lange vom Beitrag zu befreien.
